### PR TITLE
Allow EventManager to be constructed without DOM element

### DIFF
--- a/docs/api-reference/event-manager.md
+++ b/docs/api-reference/event-manager.md
@@ -34,8 +34,8 @@ Creates a new `EventManager` instance.
 
 `new EventManager(element, {events, recognizers})`
 
-*  `element` {DOM Element} - DOM element on which event handlers will be registered.
-*  `options` {Object} -  Options
+*  `element` {DOM Element, optional} - DOM element on which event handlers will be registered.
+*  `options` {Object, optional} -  Options
 *  `options.events` {Object} -  Map of {event name: handler} to register on init.
 *  `options.recognizers` - {Object}  Gesture recognizers from Hammer.js to register, as an Array in [Hammer.Recognizer format](http://hammerjs.github.io/api/#hammermanager)
 *  `options.rightButton` - {Boolean}  Recognizes click and drag from pressing the right mouse button. Default `false`. If turned on, the context menu will be disabled.
@@ -48,6 +48,15 @@ Tears down internal event management implementations.
 `eventManager.destroy()`
 
 Note: It is important to call `destroy` when done since `EventManager` adds event listeners to `window`.
+
+
+### setElement
+
+Set the DOM element on which event handlers will be registered. If element has been set, events will be unregistered from the previous element.
+
+`eventManager.setElement(element)`
+
+*  `element` {DOM Element, optional} - DOM element on which event handlers will be registered.
 
 
 ### on

--- a/docs/api-reference/event-manager.md
+++ b/docs/api-reference/event-manager.md
@@ -34,7 +34,7 @@ Creates a new `EventManager` instance.
 
 `new EventManager(element, {events, recognizers})`
 
-*  `element` {DOM Element, optional} - DOM element on which event handlers will be registered.
+*  `element` {DOM Element, optional} - DOM element on which event handlers will be registered. Default `null`.
 *  `options` {Object, optional} -  Options
 *  `options.events` {Object} -  Map of {event name: handler} to register on init.
 *  `options.recognizers` - {Object}  Gesture recognizers from Hammer.js to register, as an Array in [Hammer.Recognizer format](http://hammerjs.github.io/api/#hammermanager)

--- a/examples/main/app.js
+++ b/examples/main/app.js
@@ -35,7 +35,15 @@ class Root extends Component {
     this._handleEvent = this._handleEvent.bind(this);
     this._renderCheckbox = this._renderCheckbox.bind(this);
 
-    this._eventManager = null;
+    const eventListeners = {};
+    EVENTS.forEach(eventName => {
+      if (INITIAL_OPTIONS[eventName]) {
+        eventListeners[eventName] = this._handleEvent;
+      }
+    });
+
+    this._eventManager = new EventManager(null, {events: eventListeners, rightButton: true});
+
     this.state = {
       events: [],
       options: INITIAL_OPTIONS
@@ -43,20 +51,7 @@ class Root extends Component {
   }
 
   _onLoad(ref) {
-    if (this._eventManager) {
-      this._eventManager.destroy();
-    }
-    if (ref) {
-      const eventListeners = {};
-
-      EVENTS.forEach(eventName => {
-        if (INITIAL_OPTIONS[eventName]) {
-          eventListeners[eventName] = this._handleEvent;
-        }
-      });
-
-      this._eventManager = new EventManager(ref, {events: eventListeners, rightButton: true});
-    }
+    this._eventManager.setElement(ref);
   }
 
   _onUpdateOption(evt) {

--- a/src/event-manager.js
+++ b/src/event-manager.js
@@ -44,7 +44,7 @@ function preventDefault(evt) {
 // and gestural input (e.g. 'click', 'tap', 'panstart').
 // Delegates gesture related event registration and handling to Hammer.js.
 export default class EventManager {
-  constructor(element, options = {}) {
+  constructor(element = null, options = {}) {
     this.options = options;
     this.eventHandlers = [];
 
@@ -58,21 +58,6 @@ export default class EventManager {
     if (events) {
       this.on(events);
     }
-  }
-
-  // Tear down internal event management implementations.
-  destroy() {
-    this.element.removeEventListener('contextmenu', preventDefault);
-
-    this.wheelInput.destroy();
-    this.moveInput.destroy();
-    this.keyInput.destroy();
-    this.manager.destroy();
-
-    this.wheelInput = null;
-    this.moveInput = null;
-    this.keyInput = null;
-    this.manager = null;
   }
 
   setElement(element) {
@@ -122,6 +107,21 @@ export default class EventManager {
       this._toggleRecognizer(recognizerName, true);
       this.manager.on(eventAlias, wrappedHandler);
     });
+  }
+
+  // Tear down internal event management implementations.
+  destroy() {
+    this.element.removeEventListener('contextmenu', preventDefault);
+
+    this.wheelInput.destroy();
+    this.moveInput.destroy();
+    this.keyInput.destroy();
+    this.manager.destroy();
+
+    this.wheelInput = null;
+    this.moveInput = null;
+    this.keyInput = null;
+    this.manager = null;
   }
 
   // Register an event handler function to be called on `event`.

--- a/test/event-manager.spec.js
+++ b/test/event-manager.spec.js
@@ -50,8 +50,10 @@ test('eventManager#constructor', t => {
   EventManager.prototype.on = onSpy;
 
   t.ok(eventManager, 'EventManager created');
+  t.ok(eventManager.manager, 'Hammer.Manager created');
   t.ok(eventManager.wheelInput, 'WheelInput created');
   t.ok(eventManager.moveInput, 'MoveInput created');
+  t.ok(eventManager.keyInput, 'MoveInput created');
   t.notOk(onSpy.called, 'on() not called if options.events not passed');
 
   eventManager = new EventManager(eventRegistrar, {
@@ -60,22 +62,60 @@ test('eventManager#constructor', t => {
   });
   t.ok(onSpy.called, 'on() is called if options.events is passed');
   EventManager.prototype.on = origOn;
+
+  // construct without element
+  eventManager = new EventManager();
+  t.ok(eventManager, 'EventManager created');
+  t.notOk(eventManager.manager, 'Hammer.Manager should not be created');
+
   t.end();
 });
 
 test('eventManager#destroy', t => {
   const eventManager = new EventManager(createEventRegistrarMock());
-  spy(eventManager.manager, 'destroy');
-  spy(eventManager.moveInput, 'destroy');
-  spy(eventManager.wheelInput, 'destroy');
+  const {manager, moveInput, wheelInput, keyInput} = eventManager;
+
+  spy(manager, 'destroy');
+  spy(moveInput, 'destroy');
+  spy(wheelInput, 'destroy');
+  spy(keyInput, 'destroy');
   eventManager.destroy();
 
-  t.equal(eventManager.manager.destroy.callCount, 1,
+  t.equal(manager.destroy.callCount, 1,
     'Manager.destroy() should be called once');
-  t.equal(eventManager.moveInput.destroy.callCount, 1,
+  t.equal(moveInput.destroy.callCount, 1,
     'MoveInput.destroy() should be called once');
-  t.equal(eventManager.wheelInput.destroy.callCount, 1,
+  t.equal(wheelInput.destroy.callCount, 1,
     'WheelInput.destroy() should be called once');
+  t.equal(keyInput.destroy.callCount, 1,
+    'KeyInput.destroy() should be called once');
+  t.end();
+});
+
+test('eventManager#setElement', t => {
+  const events = {
+    foo: () => {}
+  };
+  spy(events, 'foo');
+  const eventManager = new EventManager(null, {Manager: HammerManagerMock, events});
+  spy(eventManager, 'destroy');
+
+  eventManager.setElement(createEventRegistrarMock());
+  t.ok(eventManager.manager, 'Hammer.Manager created');
+  t.equal(eventManager.destroy.callCount, 0,
+    'Manager.destroy() should not be called');
+  eventManager.manager.emit('foo', {type: 'foo', srcEvent: {}});
+  t.equal(events.foo.callCount, 1, 'event is transfered');
+
+  const oldManager = eventManager.manager;
+  eventManager.setElement(createEventRegistrarMock());
+  t.ok(eventManager.manager, 'Hammer.Manager created');
+  t.notEqual(eventManager.manager, oldManager, 'manager has changed');
+  t.equal(eventManager.destroy.callCount, 1,
+    'Manager.destroy() should be called once');
+  eventManager.manager.emit('foo', {type: 'foo', srcEvent: {}});
+  t.equal(events.foo.callCount, 2, 'event is transfered');
+
   t.end();
 });
 


### PR DESCRIPTION
Addressing the issue raised in https://github.com/uber/react-map-gl/issues/408: EventManager can only be constructed on component mount. A double render is then required if EventManager instance is needed for render.

- EventManager can be constructed without DOM element
- Add `EventManager.setElement` method
- Tests