### PR TITLE
Fix bug where EventManager.destroy throws error if element is empty

### DIFF
--- a/src/event-manager.js
+++ b/src/event-manager.js
@@ -111,17 +111,20 @@ export default class EventManager {
 
   // Tear down internal event management implementations.
   destroy() {
-    this.element.removeEventListener('contextmenu', preventDefault);
+    if (this.element) {
+      this.element.removeEventListener('contextmenu', preventDefault);
 
-    this.wheelInput.destroy();
-    this.moveInput.destroy();
-    this.keyInput.destroy();
-    this.manager.destroy();
+      this.wheelInput.destroy();
+      this.moveInput.destroy();
+      this.keyInput.destroy();
+      this.manager.destroy();
 
-    this.wheelInput = null;
-    this.moveInput = null;
-    this.keyInput = null;
-    this.manager = null;
+      this.wheelInput = null;
+      this.moveInput = null;
+      this.keyInput = null;
+      this.manager = null;
+      this.element = null;
+    }
   }
 
   // Register an event handler function to be called on `event`.

--- a/src/event-manager.js
+++ b/src/event-manager.js
@@ -114,6 +114,8 @@ export default class EventManager {
     if (this.element) {
       this.element.removeEventListener('contextmenu', preventDefault);
 
+      // wheelInput etc. are created in setElement() and therefore
+      // cannot exist if there is no element
       this.wheelInput.destroy();
       this.moveInput.destroy();
       this.keyInput.destroy();

--- a/test/event-manager.spec.js
+++ b/test/event-manager.spec.js
@@ -90,6 +90,9 @@ test('eventManager#destroy', t => {
   t.equal(keyInput.destroy.callCount, 1,
     'KeyInput.destroy() should be called once');
 
+  eventManager.destroy();
+  t.pass('EventManager does not throw error on destroyed twice');
+
   const emptyEventManager = new EventManager();
   emptyEventManager.destroy();
   t.pass('EventManager without elements can be destroyed');

--- a/test/event-manager.spec.js
+++ b/test/event-manager.spec.js
@@ -89,6 +89,11 @@ test('eventManager#destroy', t => {
     'WheelInput.destroy() should be called once');
   t.equal(keyInput.destroy.callCount, 1,
     'KeyInput.destroy() should be called once');
+
+  const emptyEventManager = new EventManager();
+  emptyEventManager.destroy();
+  t.pass('EventManager without elements can be destroyed');
+
   t.end();
 });
 


### PR DESCRIPTION
Related to https://github.com/uber/react-map-gl/pull/419