### PR TITLE
Include dist-es6 in published npm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "module": "dist-es6/index.js",
   "files": [
     "src",
-    "dist"
+    "dist",
+    "dist-es6"
   ],
   "scripts": {
     "start": "(cd examples/main && (path-exists node_modules || npm i) && npm run start-local)",


### PR DESCRIPTION
Per https://github.com/uber/react-map-gl/pull/447, this is required for this module to work in bundlers such as parcel.