### PR TITLE
Wheel input handling improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+#### [TBD]
+- NEW: A new option `legacyBlockScroll` to EventManager that allows users to restore the default scroll behavior on wheel events
+
+#### [1.0.1] - Jan 29, 2018
+- FIX: Missing `dist-es6` in package
+
 #### [1.0.0] - Jan 9, 2018
 
 #### [1.0.0-alpha.2] - Dec 9, 2017

--- a/docs/api-reference/event-manager.md
+++ b/docs/api-reference/event-manager.md
@@ -39,6 +39,7 @@ Creates a new `EventManager` instance.
 *  `options.events` {Object} -  Map of {event name: handler} to register on init.
 *  `options.recognizers` - {Object}  Gesture recognizers from Hammer.js to register, as an Array in [Hammer.Recognizer format](http://hammerjs.github.io/api/#hammermanager)
 *  `options.rightButton` - {Boolean}  Recognizes click and drag from pressing the right mouse button. Default `false`. If turned on, the context menu will be disabled.
+*  `options.legacyBlockScroll` - {Boolean}  Blocks default page scroll behavior on wheel events. Default `true`. Set to `false` to enable scrolling. This option is for backward compatibility and will be removed in the next major release.
 
 
 ### destroy

--- a/examples/main/app.js
+++ b/examples/main/app.js
@@ -42,7 +42,11 @@ class Root extends Component {
       }
     });
 
-    this._eventManager = new EventManager(null, {events: eventListeners, rightButton: true});
+    this._eventManager = new EventManager(null, {
+      events: eventListeners,
+      rightButton: true,
+      legacyBlockScroll: false
+    });
 
     this.state = {
       events: [],
@@ -67,6 +71,7 @@ class Root extends Component {
   }
 
   _handleEvent(evt) {
+    evt.preventDefault();
     const events = this.state.events.slice(0, 30);
     events.unshift(evt);
     this.setState({events});

--- a/examples/main/constants.js
+++ b/examples/main/constants.js
@@ -49,7 +49,8 @@ export const EVENTS = [
   'swipeup',
   'swipedown',
   'keydown',
-  'keyup'
+  'keyup',
+  'wheel'
 ];
 
 export const INITIAL_OPTIONS = {
@@ -65,5 +66,6 @@ export const INITIAL_OPTIONS = {
   rotateend: true,
   panstart: true,
   panmove: true,
-  panend: true
+  panend: true,
+  wheel: true
 };

--- a/src/event-manager.js
+++ b/src/event-manager.js
@@ -35,6 +35,19 @@ import {
 
 import {whichButtons, getOffsetPosition} from './utils/event-utils';
 
+const DEFAULT_OPTIONS = {
+  // event handlers
+  events: null,
+  // custom recognizers
+  recognizers: null,
+  // Manager class
+  Manager,
+  // recognize right button gestures
+  rightButton: false,
+  // block scrolling - this is a legacy behavior and will be removed in the next version
+  legacyBlockScroll: true
+};
+
 function preventDefault(evt) {
   evt.preventDefault();
 }
@@ -45,7 +58,7 @@ function preventDefault(evt) {
 // Delegates gesture related event registration and handling to Hammer.js.
 export default class EventManager {
   constructor(element = null, options = {}) {
-    this.options = options;
+    this.options = Object.assign({}, DEFAULT_OPTIONS, options);
     this.eventHandlers = [];
 
     this._onBasicInput = this._onBasicInput.bind(this);
@@ -71,7 +84,7 @@ export default class EventManager {
     }
 
     const {options} = this;
-    const ManagerClass = options.Manager || Manager;
+    const ManagerClass = options.Manager;
 
     this.manager = new ManagerClass(element, {recognizers: options.recognizers || RECOGNIZERS})
       .on('hammer.input', this._onBasicInput);
@@ -92,7 +105,10 @@ export default class EventManager {
     // Handle events not handled by Hammer.js:
     // - mouse wheel
     // - pointer/touch/mouse move
-    this.wheelInput = new WheelInput(element, this._onOtherEvent, {enable: false});
+    this.wheelInput = new WheelInput(element, this._onOtherEvent, {
+      enable: false,
+      legacyBlockScroll: options.legacyBlockScroll
+    });
     this.moveInput = new MoveInput(element, this._onOtherEvent, {enable: false});
     this.keyInput = new KeyInput(element, this._onOtherEvent, {enable: false});
 

--- a/src/inputs/wheel-input.js
+++ b/src/inputs/wheel-input.js
@@ -29,8 +29,6 @@ const EVENT_TYPE = 'wheel';
 // Constants for normalizing input delta
 const WHEEL_DELTA_MAGIC_SCALER = 4.000244140625;
 const WHEEL_DELTA_PER_LINE = 40;
-const TRACKPAD_MAX_DELTA = 4;
-const TRACKPAD_MAX_DELTA_PER_TIME = 200;
 // Slow down zoom if shift key is held for more precise zooming
 const SHIFT_MULTIPLIER = 0.25;
 
@@ -41,12 +39,6 @@ export default class WheelInput {
     this.callback = callback;
 
     this.options = Object.assign({enable: true}, options);
-
-    this.time = 0;
-    this.wheelPosition = null;
-    this.type = null;
-    this.timeout = null;
-    this.lastValue = 0;
 
     this.events = WHEEL_EVENTS.concat(options.events || []);
 
@@ -73,7 +65,9 @@ export default class WheelInput {
     if (!this.options.enable) {
       return;
     }
-    event.preventDefault();
+    if (this.options.legacyBlockScroll) {
+      event.preventDefault();
+    }
 
     let value = event.deltaY;
     if (window.WheelEvent) {
@@ -86,64 +80,22 @@ export default class WheelInput {
       }
     }
 
-    let {
-      type,
-      timeout,
-      lastValue,
-      time
-    } = this;
-
-    const now = ((window && window.performance) || Date).now();
-    const timeDelta = now - (time || 0);
-
-    this.wheelPosition = {
+    const wheelPosition = {
       x: event.clientX,
       y: event.clientY
     };
-    time = now;
 
     if (value !== 0 && value % WHEEL_DELTA_MAGIC_SCALER === 0) {
       // This one is definitely a mouse wheel event.
-      type = 'wheel';
       // Normalize this value to match trackpad.
       value = Math.floor(value / WHEEL_DELTA_MAGIC_SCALER);
-    } else if (value !== 0 && Math.abs(value) < TRACKPAD_MAX_DELTA) {
-      // This one is definitely a trackpad event because it is so small.
-      type = 'trackpad';
-    } else if (timeDelta > 400) {
-      // This is likely a new scroll action.
-      type = null;
-      lastValue = value;
-      // Start a timeout in case this was a singular event,
-      // and delay it by up to 40ms.
-      timeout = window.setTimeout(function setTimeout() {
-        this._onWheel(event, -lastValue, this.wheelPosition);
-        type = 'wheel';
-      }.bind(this), 40);
-    } else if (!type) {
-      // This is a repeating event, but we don't know the type of event just yet.
-      // If the delta per time is small, we assume it's a fast trackpad;
-      // otherwise we switch into wheel mode.
-      type = Math.abs(timeDelta * value) < TRACKPAD_MAX_DELTA_PER_TIME ? 'trackpad' : 'wheel';
-
-      // Make sure our delayed event isn't fired again, because we accumulate
-      // the previous event (which was less than 40ms ago) into this event.
-      if (timeout) {
-        window.clearTimeout(timeout);
-        timeout = null;
-        value += lastValue;
-      }
     }
 
     if (event.shiftKey && value) {
       value = value * SHIFT_MULTIPLIER;
     }
 
-    // Only fire the callback if we actually know
-    // what type of scrolling device the user uses.
-    if (type) {
-      this._onWheel(event, -value, this.wheelPosition);
-    }
+    this._onWheel(event, -value, wheelPosition);
   }
 
   _onWheel(srcEvent, delta, position) {


### PR DESCRIPTION
#### Background
The `WheelInput` class contains legacy code from react-map-gl that detects the source device (wheel/trackpad) but the result is never exposed via the event object.
The detection technique requires setting a timer, which defeats `event.preventDefault()` by the time the user's event handler is called. This forced us to call `event.preventDefault()` inside `WheelInput`. As a result, the user cannot use the EventManager for wheel events *and* allow the page to scroll.

#### Changelist
- Remove delayed wheel event handling
- Provide an EventManager option to unblock default scroll behavior (calling it `legacyBlockScroll` to show the intent to remove in the next major release)