### PR TITLE
Add support for use in electron environments.

### DIFF
--- a/src/utils/globals.js
+++ b/src/utils/globals.js
@@ -41,11 +41,8 @@
 // Purpose: include this in your module to avoids adding dependencies on
 // micro modules like 'global' and 'is-browser';
 
-/* global process, window, global, document, navigator */
-const isBrowser =
-  typeof process !== 'object' ||
-  String(process) !== '[object process]' ||
-  process.browser;
+/* global window, global, document, navigator */
+import isBrowser from './is-browser';
 
 const userAgent = typeof navigator !== 'undefined' ?
   navigator.userAgent.toLowerCase() : '';

--- a/src/utils/is-browser.js
+++ b/src/utils/is-browser.js
@@ -1,0 +1,18 @@
+// based on https://github.com/uber/luma.gl/blob/master/src/utils/is-browser.js
+// This function is needed in initialization stages,
+// make sure it can be imported in isolation
+/* global process */
+
+import isElectron from './is-electron';
+
+const isNode =
+  typeof process === 'object' &&
+  String(process) === '[object process]' &&
+  !process.browser;
+
+const isBrowser = !isNode || isElectron;
+
+// document does not exist on worker thread
+export const isBrowserMainThread = isBrowser && typeof document !== 'undefined';
+
+export default isBrowser;

--- a/src/utils/is-electron.js
+++ b/src/utils/is-electron.js
@@ -1,0 +1,22 @@
+// based on https://github.com/uber/luma.gl/blob/master/src/utils/is-electron.js
+/* global window, process, navigator */
+function isElectron() {
+  // Renderer process
+  if (typeof window !== 'undefined' && typeof window.process === 'object' &&
+    window.process.type === 'renderer') {
+    return true;
+  }
+  // Main process
+  if (typeof process !== 'undefined' && typeof process.versions === 'object' &&
+    Boolean(process.versions.electron)) {
+    return true;
+  }
+  // Detect the user agent when the `nodeIntegration` option is set to true
+  if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' &&
+    navigator.userAgent.indexOf('Electron') >= 0) {
+    return true;
+  }
+  return false;
+}
+
+export default isElectron();


### PR DESCRIPTION
When running code inside electron browser windows, process.browser is undefined. This adds is-electron.js to check if the environment is running inside an electron browser window with nodeIntegration set to true which is a valid browser environment.

See:
https://github.com/uber/luma.gl/blob/master/src/utils/is-electron.js
https://github.com/uber/luma.gl/blob/master/src/utils/is-browser.js
https://github.com/cheton/is-electron
https://github.com/electron/electron/issues/2288