### PR TITLE
Remove commonjs to fix the problem with cjs/esm interop

### DIFF
--- a/src/utils/globals.js
+++ b/src/utils/globals.js
@@ -42,15 +42,15 @@
 // micro modules like 'global' and 'is-browser';
 
 /* global window, global, document, navigator */
-const isBrowser = require('./is-browser').default;
-
-const userAgent = typeof navigator !== 'undefined' ?
+export const userAgent = typeof navigator !== 'undefined' ?
   navigator.userAgent.toLowerCase() : '';
 
-module.exports = {
-  window: typeof window !== 'undefined' ? window : global,
-  global: typeof global !== 'undefined' ? global : window,
-  document: typeof document !== 'undefined' ? document : {},
-  isBrowser,
-  userAgent
+const window_ = typeof window !== 'undefined' ? window : global;
+const global_ = typeof global !== 'undefined' ? global : window;
+const document_ = typeof document !== 'undefined' ? document : {};
+
+export {
+  window_ as window,
+  global_ as global,
+  document_ as document
 };

--- a/src/utils/hammer.js
+++ b/src/utils/hammer.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {isBrowser} from './globals';
+import isBrowser from './is-browser';
 import {enhancePointerEventInput, enhanceMouseInput} from './hammer-overrides';
 
 let hammerjs;


### PR DESCRIPTION
This diff fixes bundling app with mjolnir by rollup. Currently to do
this I add this custom plugin

```js
{
  name: 'hammerjs-import',
  load(id) {
    if (id.includes('mjolnir.js') && id.includes('globals.js')) {
      return `
        export var userAgent = navigator.userAgent.toLowerCase();
        export var isBrowser = true;
        export {
          window,
          window as global,
          document
        }
      `;
    }
  },
  transform(code, id) {
    if (
      code.includes(`require("hammerjs")`) ||
      code.includes(`require('hammerjs')`)
    ) {
      const importStatement = 'import __hammerjs__ from "hammerjs";\n';
      const processed = code.replace(
        /require\(["']hammerjs["']\)/g,
        '__hammerjs__',
      );
      return {
        code: importStatement + processed,
      };
    }
  },
}
```

This diff will let me to remove at least `load` hook. Would be good to
see this publish as patch.