### PR TITLE
Add anyclick event

### DIFF
--- a/docs/api-reference/event-manager.md
+++ b/docs/api-reference/event-manager.md
@@ -128,7 +128,8 @@ Mouse event and pointer event names are interchangeable.
 
 ### Gesture events
 See [hammer.js](http://hammerjs.github.io/) for documentation of the following events.
-- `'tap'` | `click`
+- `'tap'` | `click` - a single click. Not fired if double clicking.
+- `'anytap'` | `anyclick` - like `click`, but fired twice if double clicking.
 - `'doubletap'` | `dblclick`
 - `'press'`
 - `'pan'`

--- a/examples/main/constants.js
+++ b/examples/main/constants.js
@@ -20,6 +20,7 @@
 
 export const EVENTS = [
   'click',
+  'anyclick',
   'contextmenu',
   'pointerdown',
   'pointermove',
@@ -59,10 +60,6 @@ export const EVENTS = [
 export const INITIAL_OPTIONS = {
   click: true,
   doubletap: true,
-  pointermove: true,
-  pointerover: true,
-  pointerout: true,
-  pointerleave: true,
   pinchstart: true,
   pinchmove: true,
   pinchend: true,

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,12 +29,16 @@ export const RECOGNIZERS = Hammer ? [
   [Hammer.Pan, {threshold: 0, enable: false}],
   [Hammer.Press, {enable: false}],
   [Hammer.Tap, {event: 'doubletap', taps: 2, enable: false}],
+  // TODO - rename to 'tap' and 'singletap' in the next major release
+  [Hammer.Tap, {event: 'anytap', enable: false}],
   [Hammer.Tap, {enable: false}]
 ] : null;
 
 // Recognize the following gestures even if a given recognizer succeeds
 export const RECOGNIZER_COMPATIBLE_MAP = {
-  rotate: ['pinch']
+  rotate: ['pinch'],
+  doubletap: ['anytap'],
+  anytap: ['tap']
 };
 
 // Recognize the folling gestures only if a given recognizer fails
@@ -92,6 +96,7 @@ export const INPUT_EVENT_TYPES = {
  */
 export const EVENT_RECOGNIZER_MAP = {
   tap: 'tap',
+  anytap: 'anytap',
   doubletap: 'doubletap',
   press: 'press',
   pinch: 'pinch',
@@ -129,6 +134,7 @@ export const EVENT_RECOGNIZER_MAP = {
  */
 export const GESTURE_EVENT_ALIASES = {
   click: 'tap',
+  anyclick: 'anytap',
   dblclick: 'doubletap',
   mousedown: 'pointerdown',
   mousemove: 'pointermove',


### PR DESCRIPTION
Add a new event `anyclick` (see documentation in this PR).
The naming is awkward and I plan to rename the current `click` to `singleclick` in the next major release.