### PR TITLE
Add tabIndex option; change default to 0

### DIFF
--- a/docs/api-reference/event-manager.md
+++ b/docs/api-reference/event-manager.md
@@ -37,7 +37,7 @@ Creates a new `EventManager` instance.
 - `options.recognizerOptions` - {Object} Override the default options of `recognizers`. Keys are recognizer names and values are recognizer options. For a list of default recognizers, see "Gesture Events" section below.
 - `options.rightButton` - {Boolean} Recognizes click and drag from pressing the right mouse button. Default `false`. If turned on, the context menu will be disabled.
 - `options.touchAction` - {String} Allow browser default touch actions. Default `none`. See [hammer.js doc](http://hammerjs.github.io/touch-action/).
-- `options.legacyBlockScroll` - {Boolean} Blocks default page scroll behavior on wheel events. Default `true`. Set to `false` to enable scrolling. This option is for backward compatibility and will be removed in the next major release.
+- `options.tabIndex` - {Number} The [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) of the root element. Default `0`.
 
 ### destroy
 

--- a/src/event-manager.js
+++ b/src/event-manager.js
@@ -46,7 +46,8 @@ const DEFAULT_OPTIONS = {
   Manager,
   // allow browser default touch action
   // https://github.com/uber/react-map-gl/issues/506
-  touchAction: 'none'
+  touchAction: 'none',
+  tabIndex: 0
 };
 
 // Unified API for subscribing to events about both
@@ -122,7 +123,8 @@ export default class EventManager {
       enable: false
     });
     this.keyInput = new KeyInput(element, this._onOtherEvent, {
-      enable: false
+      enable: false,
+      tabIndex: options.tabIndex
     });
     this.contextmenuInput = new ContextmenuInput(element, this._onOtherEvent, {
       enable: false

--- a/src/inputs/key-input.js
+++ b/src/inputs/key-input.js
@@ -37,7 +37,7 @@ export default class KeyInput {
 
     this.handleEvent = this.handleEvent.bind(this);
 
-    element.tabIndex = 1;
+    element.tabIndex = options.tabIndex || 0;
     element.style.outline = 'none';
     this.events.forEach(event => element.addEventListener(event, this.handleEvent));
   }


### PR DESCRIPTION
For https://github.com/uber/react-map-gl/issues/1001

[tabIndex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) is required for the element to receive keyboard events.