### PR TITLE
[FIX] Fix `hammerjs` import

### DIFF
--- a/src/utils/hammer.browser.ts
+++ b/src/utils/hammer.browser.ts
@@ -1,4 +1,4 @@
-import hammerjs from 'hammerjs';
+import * as hammerjs from 'hammerjs';
 import {enhancePointerEventInput, enhanceMouseInput} from './hammer-overrides';
 
 enhancePointerEventInput(hammerjs.PointerEventInput);


### PR DESCRIPTION
Do `import * as hammerjs from 'hammerjs'` because hammer doesn't have a default export.

The TS gets compiled down into this ES5 code:
```js
(0, hammer_overrides_1.enhancePointerEventInput)(hammerjs_1.default.PointerEventInput);
```

This throws the following error because `hammerjs_1.default` is undefined:
```
index.js:11207 Uncaught TypeError: Cannot read properties of undefined (reading 'PointerEventInput')
    at eval (hammer.browser.js?9ba0:6:1)
    at Object../node_modules/mjolnir.js/dist/es5/utils/hammer.browser.js (index.js:8143:1)
    at __webpack_require__ (index.js:11204:33)
    at fn (index.js:11404:21)
    at eval (event-manager.js?deab:41:16)
    at Object../node_modules/mjolnir.js/dist/es5/event-manager.js (index.js:8022:1)
    at __webpack_require__ (index.js:11204:33)
    at fn (index.js:11404:21)
    at eval (index.js?4574:4:23)
    at Object../node_modules/mjolnir.js/dist/es5/index.js (index.js:8033:1)
```